### PR TITLE
Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ bin
 # Ncqrs in non framework solution
 /Extensions/lib/Ncqrs/*
 /Samples/MyNotes/lib/*
+/lib/*
 release

--- a/Framework/src/Ncqrs/Eventing/Storage/AttributeEventTypeResolver.cs
+++ b/Framework/src/Ncqrs/Eventing/Storage/AttributeEventTypeResolver.cs
@@ -184,7 +184,7 @@ namespace Ncqrs.Eventing.Storage
     /// 
     /// This name is only used when de-serializing an event.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     public class EventNameAliasAttribute : Attribute
     {
         public EventNameAliasAttribute(string name)


### PR DESCRIPTION
EventNameAliasAttribute is allowed multiple times on a event.

For example we have this in our codebase:

```
[Serializable]
[EventName("foo:bar:baz:current")]
[EventNameAlias("foo:bar:baz:curent")]
[EventNameAlias("foo:bar:baz:current, foo.bar.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null")]
```
