### PR TITLE
Development

### DIFF
--- a/Framework/src/Ncqrs.Tests/Eventing/Storage/NoDB/EventStoreTests/NoDBEventStoreTests.cs
+++ b/Framework/src/Ncqrs.Tests/Eventing/Storage/NoDB/EventStoreTests/NoDBEventStoreTests.cs
@@ -19,18 +19,20 @@ namespace Ncqrs.Eventing.Storage.NoDB.Tests.EventStoreTests
         {
             EventStore = new NoDBEventStore("./");
             Source = MockRepository.GenerateMock<IEventSource>();
-            Guid id = Guid.NewGuid();
+            Guid aggregateId = Guid.NewGuid();
+            Guid entityId = Guid.NewGuid();
             int sequenceCounter = 1;
             Events = new SourcedEvent[]
                          {
-                             new CustomerCreatedEvent(Guid.NewGuid(), id, sequenceCounter++, DateTime.UtcNow, "Foo",
-                                                      35),
-                             new CustomerNameChanged(Guid.NewGuid(), id, sequenceCounter++, DateTime.UtcNow,
-                                                     "Name" + sequenceCounter),
-                             new CustomerNameChanged(Guid.NewGuid(), id, sequenceCounter++, DateTime.UtcNow,
-                                                     "Name" + sequenceCounter)
+                             //new CustomerCreatedEvent(Guid.NewGuid(), aggregateId, sequenceCounter++, DateTime.UtcNow, "Foo",
+                             //                         35),
+                             //new CustomerNameChanged(Guid.NewGuid(), aggregateId, sequenceCounter++, DateTime.UtcNow,
+                             //                        "Name" + sequenceCounter),
+                             //new CustomerNameChanged(Guid.NewGuid(), aggregateId, sequenceCounter++, DateTime.UtcNow,
+                             //                        "Name" + sequenceCounter),
+                             new AccountTitleChangedEvent(Guid.NewGuid(), aggregateId, entityId, sequenceCounter++, DateTime.UtcNow, "Title" + sequenceCounter )
                          };
-            Source.Stub(e => e.EventSourceId).Return(id);
+            Source.Stub(e => e.EventSourceId).Return(aggregateId);
             Source.Stub(e => e.InitialVersion).Return(0);
             Source.Stub(e => e.Version).Return(Events.Length);
             Source.Stub(e => e.GetUncommittedEvents()).Return(Events);

--- a/Framework/src/Ncqrs.Tests/Eventing/Storage/NoDB/Fakes/AccountTitleChangedEvent.cs
+++ b/Framework/src/Ncqrs.Tests/Eventing/Storage/NoDB/Fakes/AccountTitleChangedEvent.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Ncqrs.Eventing.Sourcing;
+
+namespace Ncqrs.Eventing.Storage.NoDB.Tests.Fakes
+{
+    [Serializable]
+    public class AccountTitleChangedEvent : SourcedEntityEvent
+    {
+        public AccountTitleChangedEvent()
+        {
+        }
+
+        public AccountTitleChangedEvent(Guid eventIdentifier, Guid eventSourceId, Guid entityId, long eventSequence,
+                                    DateTime eventTimeStamp, string newTitle)
+            : base(eventIdentifier, eventSourceId, entityId, eventSequence, eventTimeStamp)
+        {
+            NewTitle = newTitle;
+        }
+
+        public string NewTitle { get; set; }
+
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as AccountTitleChangedEvent;
+            if (other == null) return false;
+            bool result = EventIdentifier.Equals(other.EventIdentifier) &&
+                          EventSourceId.Equals(other.EventSourceId) &&
+                          EntityId.Equals(other.EntityId) &&
+                          EventSequence.Equals(other.EventSequence) &&
+                          EventTimeStamp.Equals(other.EventTimeStamp) &&
+                          NewTitle.Equals(other.NewTitle);
+            return result;
+        }
+    }
+}

--- a/Framework/src/Ncqrs.Tests/Ncqrs.Tests.csproj
+++ b/Framework/src/Ncqrs.Tests/Ncqrs.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -122,6 +122,7 @@
     <Compile Include="Eventing\Storage\NoDB\EventStoreTests\when_getting_the_events_since_a_specific_version.cs" />
     <Compile Include="Eventing\Storage\NoDB\EventStoreTests\when_saving_a_new_event_source.cs" />
     <Compile Include="Eventing\Storage\NoDB\EventStoreTests\when_saving_events_based_on_stale_state.cs" />
+    <Compile Include="Eventing\Storage\NoDB\Fakes\AccountTitleChangedEvent.cs" />
     <Compile Include="Eventing\Storage\NoDB\Fakes\CustomerCreatedEvent.cs" />
     <Compile Include="Eventing\Storage\NoDB\Fakes\CustomerNameChanged.cs" />
     <Compile Include="Eventing\Storage\NoDB\Fakes\TestSnapshot.cs" />

--- a/Framework/src/Ncqrs/Eventing/Sourcing/ISourcedEntityEvent.cs
+++ b/Framework/src/Ncqrs/Eventing/Sourcing/ISourcedEntityEvent.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ncqrs.Eventing.Sourcing
+{
+    public interface ISourcedEntityEvent : ISourcedEvent
+    {
+        Guid EntityId { get;}
+    }
+
+    internal interface  IAllowSettingEntityId
+    {
+        void SetEntityId(Guid entityId);
+    }
+}

--- a/Framework/src/Ncqrs/Eventing/Sourcing/SourcedEntityEvent.cs
+++ b/Framework/src/Ncqrs/Eventing/Sourcing/SourcedEntityEvent.cs
@@ -2,7 +2,7 @@
 
 namespace Ncqrs.Eventing.Sourcing
 {
-    public class SourcedEntityEvent : SourcedEvent
+    public class SourcedEntityEvent : SourcedEvent, ISourcedEntityEvent, IAllowSettingEntityId
     {
         public static Guid UndefinedEntityId = Guid.Empty;
 
@@ -17,6 +17,11 @@ namespace Ncqrs.Eventing.Sourcing
         }
 
         public SourcedEntityEvent(Guid eventIdentifier, Guid eventSourceId, Guid entityId, long eventSequence, DateTime eventTimeStamp) : base(eventIdentifier, eventSourceId, eventSequence, eventTimeStamp)
+        {
+            EntityId = entityId;
+        }
+
+        public void SetEntityId(Guid entityId)
         {
             EntityId = entityId;
         }

--- a/Framework/src/Ncqrs/Ncqrs.csproj
+++ b/Framework/src/Ncqrs/Ncqrs.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Domain\Storage\IAggregateRootCreationStrategy.cs" />
     <Compile Include="Domain\Storage\SimpleAggregateRootCreationStrategy.cs" />
     <Compile Include="Eventing\Sourcing\EntityThresholdedDomainEventHandlerWrapper.cs" />
+    <Compile Include="Eventing\Sourcing\ISourcedEntityEvent.cs" />
     <Compile Include="Eventing\Sourcing\SourcedEventArgs.cs" />
     <Compile Include="Eventing\Sourcing\SourcedEntityEvent.cs" />
     <Compile Include="Eventing\Storage\NoDB\NoDBEventStore.cs" />


### PR DESCRIPTION
SourcedEntityEvents don't get their EntityId hydrated during deserialisation in JSonFormatter. This means the EntityId is Guid.Empty resulting in errors during event handler calls.
