### PR TITLE
Development

### DIFF
--- a/Framework/src/Ncqrs.Tests/Domain/AggregateRootTests.cs
+++ b/Framework/src/Ncqrs.Tests/Domain/AggregateRootTests.cs
@@ -360,5 +360,28 @@ namespace Ncqrs.Tests.Domain
 
             theAggregate.FooEventHandlerInvokeCount.Should().Be(eventHandlerCountAfterInitialization + 1);
         }
+
+        [Test]
+        public void Should_be_able_to_register_RegisterThreadStaticEventAppliedCallbacks_from_parallel_threads()
+        {
+            Action<AggregateRoot, ISourcedEvent> callback = (x, y) => { };
+
+            Action registerOneCallbackOnAggregateRoot = () => AggregateRoot.RegisterThreadStaticEventAppliedCallback(callback);
+            Action registerTwoCallbacksOnAggregateRoot = () => 
+            {
+                AggregateRoot.RegisterThreadStaticEventAppliedCallback(callback);
+                AggregateRoot.RegisterThreadStaticEventAppliedCallback(callback);
+            };
+
+            System.Threading.Tasks.Parallel.Invoke(
+                registerOneCallbackOnAggregateRoot,
+                registerTwoCallbacksOnAggregateRoot,
+                registerOneCallbackOnAggregateRoot,
+                registerTwoCallbacksOnAggregateRoot,
+                registerOneCallbackOnAggregateRoot,
+                registerTwoCallbacksOnAggregateRoot,
+                registerOneCallbackOnAggregateRoot,
+                registerTwoCallbacksOnAggregateRoot);
+        }
     }
 }

--- a/Framework/src/Ncqrs/Domain/AggregateRoot.cs
+++ b/Framework/src/Ncqrs/Domain/AggregateRoot.cs
@@ -11,16 +11,29 @@ namespace Ncqrs.Domain
     public abstract class AggregateRoot : EventSource
     {
         [ThreadStatic]
-        private static readonly List<Action<AggregateRoot, ISourcedEvent>> _eventAppliedCallbacks = new List<Action<AggregateRoot, ISourcedEvent>>();
+        private static List<Action<AggregateRoot, ISourcedEvent>> _eventAppliedCallbacks;
+
+        private static List<Action<AggregateRoot, ISourcedEvent>> EventAppliedCallbacks
+        {
+            get
+            {
+                if (_eventAppliedCallbacks == null)
+                {
+                    _eventAppliedCallbacks = new List<Action<AggregateRoot, ISourcedEvent>>();
+                }
+
+                return _eventAppliedCallbacks;
+            }
+        }
 
         public static void RegisterThreadStaticEventAppliedCallback(Action<AggregateRoot, ISourcedEvent> callback)
         {
-            _eventAppliedCallbacks.Add(callback);
+            EventAppliedCallbacks.Add(callback);
         }
 
         public static void UnregisterThreadStaticEventAppliedCallback(Action<AggregateRoot, ISourcedEvent> callback)
         {
-            _eventAppliedCallbacks.Remove(callback);
+            EventAppliedCallbacks.Remove(callback);
         }
 
         protected AggregateRoot()
@@ -32,7 +45,7 @@ namespace Ncqrs.Domain
         [NoEventHandler]
         protected override void OnEventApplied(ISourcedEvent appliedEvent)
         {
-            var callbacks = _eventAppliedCallbacks;
+            var callbacks = EventAppliedCallbacks;
 
             foreach(var callback in callbacks)
             {


### PR DESCRIPTION
AggregateRoot.cs has a major bug where there's a ThreadStatic collection being initialised at declaration. ThreadStatic variables must never be initialised in such a manner as it will result in only the first instance getting initialized. Instances for other threads will see their corresponding instances uninitialised.

This commit fixes the issue and has a corresponding unit test to prove it.
