### PR TITLE
Development

### DIFF
--- a/Framework/src/Ncqrs/Eventing/ServiceModel/Bus/RegisterAllHandlersInAssemblyExtension.cs
+++ b/Framework/src/Ncqrs/Eventing/ServiceModel/Bus/RegisterAllHandlersInAssemblyExtension.cs
@@ -50,6 +50,7 @@ namespace Ncqrs.Eventing.ServiceModel.Bus
         private static bool ImplementsAtLeastOneIEventHandlerInterface(Type type)
         {
             return type.IsClass &&
+                   !type.IsAbstract &&
                    type.GetInterfaces().Any(IsIEventHandlerInterface);
         }
 


### PR DESCRIPTION
For "bus.RegisterAllHandlersInAssembly(myDenormalizerAssembly);" if an event handler interface is on an abstract base class, the abstract base class is registered with the bus as well as the concrete implementation.

For example, this doesn't work:

```
public abstract class Denormalizer<T> : IEventHandler<T> 
{ 
    // Do some common infrastructure-y stuff here

    // Handle the event
    public abstract void Handle(T evnt);
}

public class SomethingDenormalizer : Denormalizer<SomethingCreatedEvent> 
{
    public override void Handle(SomethingCreatedEvent evnt)
    {
        var session = base.GetSession();
    }
} 
```

Yes, it's a wacky way to structure things.
