### PR TITLE
Entity and EntityMappedByConvention now Serializable

### DIFF
--- a/Framework/src/Ncqrs/Domain/Entity.cs
+++ b/Framework/src/Ncqrs/Domain/Entity.cs
@@ -6,6 +6,7 @@ namespace Ncqrs.Domain
     /// <summary>
     /// The abstract concept of an entity -- an object living inside an aggregate with own thread of identity.
     /// </summary>
+    [Serializable]
     public abstract class Entity : Entity<AggregateRoot>
     {
         protected Entity(AggregateRoot parent, Guid entityId)
@@ -17,6 +18,7 @@ namespace Ncqrs.Domain
     /// <summary>
     /// The abstract concept of an entity -- an object living inside an aggregate with own thread of identity.
     /// </summary>
+    [Serializable]
     public abstract class Entity<TAggregateRoot> where TAggregateRoot : AggregateRoot
     {
         private readonly Guid _entityId;

--- a/Framework/src/Ncqrs/Domain/EntityMappedByConvention.cs
+++ b/Framework/src/Ncqrs/Domain/EntityMappedByConvention.cs
@@ -4,6 +4,7 @@ using Ncqrs.Eventing.Sourcing.Mapping;
 
 namespace Ncqrs.Domain
 {
+    [Serializable]
     public abstract class EntityMappedByConvention : EntityMappedByConvention<AggregateRoot>
     {
         protected EntityMappedByConvention(AggregateRoot parent, Guid entityId) : base(parent, entityId)
@@ -11,6 +12,7 @@ namespace Ncqrs.Domain
         }
     }
 
+    [Serializable]
     public abstract class EntityMappedByConvention<TAggregateRoot> : Entity<TAggregateRoot> where TAggregateRoot : AggregateRoot
     {
         protected EntityMappedByConvention(TAggregateRoot parent, Guid entityId)


### PR DESCRIPTION
Entity and EntityMappedByConvention are now marked Serializable, this allows snapshotting of AR that contain entities.
