### PR TITLE
Feature event envelope

### DIFF
--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/Env/NoteChanged.cs
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/Env/NoteChanged.cs
@@ -9,7 +9,6 @@ namespace Ncqrs.Eventing.Storage.WindowsAzure.Tests.Env
     [Serializable]
     public class NoteChanged : SourcedEvent
     {
-        public Guid NoteId { get; set; }
         public string NewNoteText { get; set; }
     }
 }

--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/Env/NoteCreated.cs
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/Env/NoteCreated.cs
@@ -9,7 +9,6 @@ namespace Ncqrs.Eventing.Storage.WindowsAzure.Tests.Env
     [Serializable]
     public class NoteCreated : SourcedEvent
     {
-        Guid NoteId { get; set; }
         public string NoteText { get; set; }
     }
 }

--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/Env/Startup.cs
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/Env/Startup.cs
@@ -14,7 +14,13 @@ namespace Ncqrs.Eventing.Storage.WindowsAzure.Tests.Env
         {
             NcqrsEnvironment.SetDefault<IEventStore>(new TableOnlyStore("MainTest"));
             //NcqrsEnvironment.SetDefault<IEventStore>(new MsSqlServerEventStore(@"Server=.\SQLExpress;Initial Catalog=MyNotesEventStore;Integrated Security=SSPI"));
+            //NcqrsEnvironment.SetDefault<IEventStore>(new TableOnlyStore(new Microsoft.WindowsAzure.CloudStorageAccount(
+            //    new Microsoft.WindowsAzure.StorageCredentialsAccountAndKey("gr1dstorage", "tE27H62FJNm4vs9e0lOdhUilMXbhKcq53CrEznepGjvfd4lwXKcSB7UFeX9pN+32884mUduEkk3ZJ205FjVmhQ=="),
+            //    true),
+            //    "MainTest"));
+            
             CommandService c = new CommandService();
+
             
             c.RegisterExecutorsInAssembly(typeof(CreateNoteCommand).Assembly);
 

--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/MainTests.cs
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/MainTests.cs
@@ -44,7 +44,7 @@ namespace Ncqrs.Eventing.Storage.WindowsAzure.Tests
         {
             IList<Guid> ids = new List<Guid>();
 
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < 10; i++)
             {
                 Guid id = Guid.NewGuid();
                 ids.Add(id);

--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/Ncqrs.Eventing.Storage.WindowsAzure.Tests.csproj
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure.Tests/Ncqrs.Eventing.Storage.WindowsAzure.Tests.csproj
@@ -35,7 +35,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Newtonsoft.Json">
+    <Reference Include="Newtonsoft.Json, Version=3.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\lib\ThirdParty\json.net\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Ncqrs.Eventing.Storage.WindowsAzure.csproj
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Ncqrs.Eventing.Storage.WindowsAzure.csproj
@@ -30,12 +30,19 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>Ncqrs.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.WindowsAzure.StorageClient, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\lib\ThirdParty\WindowsAzureStorageClient\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
+    <Reference Include="Newtonsoft.Json, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b9a188c8922137c6, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\lib\ThirdParty\json.net\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
@@ -54,12 +61,16 @@
     <Compile Include="Table\NcqrsEventSource.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Table\TableOnlyStore.cs" />
+    <Compile Include="Utility.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Framework\src\Ncqrs\Ncqrs.csproj">
       <Project>{01F84441-80D3-49B4-AB18-96894ACB2F90}</Project>
       <Name>Ncqrs</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Ncqrs.snk" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Table/NcqrsEvent.cs
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Table/NcqrsEvent.cs
@@ -14,7 +14,7 @@ namespace Ncqrs.Eventing.Storage.WindowsAzure
         public string Name { get; set; }
         public string Version { get; set; }
         public long Sequence { get; set; }
-        public byte[] Data { get; set; }
+        public string Data { get; set; }
         
         public NcqrsEvent()
         {
@@ -24,17 +24,13 @@ namespace Ncqrs.Eventing.Storage.WindowsAzure
             base(@event.EventSourceId.ToString(), @event.EventIdentifier.ToString())
         {
             base.Timestamp = @event.EventTimeStamp;
-            Name = @event.Payload.GetType().FullName;
+            Name = @event.Payload.GetType().AssemblyQualifiedName;
             Sequence = @event.EventSequence;
             Version = @event.EventVersion.ToString();
 
             if (@event.Payload != null)
             {
-                using (MemoryStream ms = new MemoryStream())
-                {
-                    new BinaryFormatter().Serialize(ms, @event.Payload);
-                    Data = ms.ToArray();
-                }
+                Data = Utility.JsonizeTo(@event.Payload);
             }
         }
     }

--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Utility.cs
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Utility.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.IO;
+using Ncqrs.Eventing.Storage.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Ncqrs.Eventing.Storage.WindowsAzure 
+{
+    public class Utility 
+    {
+        public static object DeserializeFrom(byte[] bytes)
+        {
+            return new BinaryFormatter().Deserialize(new MemoryStream(bytes));
+        }
+
+        public static byte[] SerializeTo(object payload)
+        {
+            using (MemoryStream output = new MemoryStream())
+            {
+                new BinaryFormatter().Serialize(output, payload);
+                return output.ToArray();
+            }
+        }
+
+        public static string JsonizeTo(object payload)
+        {
+            using(StringWriter sw = new StringWriter())
+            {
+                new JsonSerializer().Serialize(sw, payload);
+                return sw.ToString();
+            }
+        }
+
+        public static object JsonizeFrom(string json, Type type)
+        {
+            return new JsonSerializer().Deserialize(new StringReader(json), type);
+        }
+
+        public static object JsonizeFrom(string json, string typeName)
+        {
+            Type returnType = Type.GetType(typeName, true, false);
+            return JsonizeFrom(json, returnType );
+        }
+
+
+    }
+}

--- a/Framework/src/Ncqrs/Eventing/CommittedEventStream.cs
+++ b/Framework/src/Ncqrs/Eventing/CommittedEventStream.cs
@@ -22,8 +22,6 @@ namespace Ncqrs.Eventing
             {
                 var last = _events.Last();
                 _currentSourceVersion = last.EventSequence;
-
-                _currentSourceVersion = _events.OrderByDescending(evnt => evnt.EventSequence).First().EventSequence;
                 _sourceId = last.EventSourceId;
             }
         }

--- a/Framework/src/Ncqrs/Ncqrs.csproj
+++ b/Framework/src/Ncqrs/Ncqrs.csproj
@@ -78,6 +78,12 @@
     <CodeContractsRuntimeCheckingLevel>Full</CodeContractsRuntimeCheckingLevel>
     <CodeContractsReferenceAssembly>%28none%29</CodeContractsReferenceAssembly>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>Ncqrs.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
       <HintPath>..\..\..\lib\ThirdParty\log4net\log4net.dll</HintPath>
@@ -85,8 +91,7 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\lib\ThirdParty\json.net\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\..\..\..\root\gr1d.org\team\Shared\lib\json.net\Release\Net\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -240,7 +245,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TraceLogger.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Ncqrs.snk" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>

--- a/Framework/src/Ncqrs/Properties/AssemblyInfo.cs
+++ b/Framework/src/Ncqrs/Properties/AssemblyInfo.cs
@@ -14,8 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © Ncqrs 2010")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: InternalsVisibleTo("Ncqrs.Tests")]
-[assembly: InternalsVisibleTo("Ncqrs.Spec")]
+
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Ncqrs.Master.sln
+++ b/Ncqrs.Master.sln
@@ -148,16 +148,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ncqrs.Eventing.Storage.WindowsAzure.Tests", "Extensions\src\Ncqrs.Eventing.Storage.WindowsAzure.Tests\Ncqrs.Eventing.Storage.WindowsAzure.Tests.csproj", "{693DEFC5-355C-4F62-B424-3119046B5F6D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9961F987-2519-493C-83E6-5E8AFCD32291}"
-	ProjectSection(SolutionItems) = preProject
-		Local.testsettings = Local.testsettings
-		Ncqrs.Master.vsmdi = Ncqrs.Master.vsmdi
-		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
-	EndProjectSection
 EndProject
 Global
-	GlobalSection(TestCaseManagementSettings) = postSolution
-		CategoryFile = Ncqrs.Master.vsmdi
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms


### PR DESCRIPTION
Changes to Azure Event Store as follows:
- Hardcoded to better support InitializeFromHistory (to make sure InitialVersion is correct)
- Split the table when used in Development Azure Storage Emulator, as emulator doesn't support jagged tables (different typed entities in the one table).  However 1 table remains in production to ensure write consistency
- Changed to json serialization
  TODO:  Some help on the Event Versioning would be great
