### PR TITLE
Development

### DIFF
--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Ncqrs.Eventing.Storage.WindowsAzure.csproj
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Ncqrs.Eventing.Storage.WindowsAzure.csproj
@@ -35,6 +35,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\lib\ThirdParty\WindowsAzureStorageClient\Microsoft.WindowsAzure.StorageClient.dll</HintPath>
     </Reference>
+    <Reference Include="Ncqrs">
+      <HintPath>..\..\..\lib\Debug\Ncqrs\Ncqrs.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\lib\ThirdParty\json.net\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -54,12 +57,7 @@
     <Compile Include="Table\NcqrsEventSource.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Table\TableOnlyStore.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Framework\src\Ncqrs\Ncqrs.csproj">
-      <Project>{01F84441-80D3-49B4-AB18-96894ACB2F90}</Project>
-      <Name>Ncqrs</Name>
-    </ProjectReference>
+    <Compile Include="Utility.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Table/NcqrsEvent.cs
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Table/NcqrsEvent.cs
@@ -14,7 +14,7 @@ namespace Ncqrs.Eventing.Storage.WindowsAzure
         public string Name { get; set; }
         public string Version { get; set; }
         public long Sequence { get; set; }
-        public byte[] Data { get; set; }
+        public string Data { get; set; }
         
         public NcqrsEvent()
         {
@@ -24,17 +24,13 @@ namespace Ncqrs.Eventing.Storage.WindowsAzure
             base(@event.EventSourceId.ToString(), @event.EventIdentifier.ToString())
         {
             base.Timestamp = @event.EventTimeStamp;
-            Name = @event.Payload.GetType().FullName;
+            Name = @event.Payload.GetType().AssemblyQualifiedName;
             Sequence = @event.EventSequence;
             Version = @event.EventVersion.ToString();
 
             if (@event.Payload != null)
             {
-                using (MemoryStream ms = new MemoryStream())
-                {
-                    new BinaryFormatter().Serialize(ms, @event.Payload);
-                    Data = ms.ToArray();
-                }
+                Data = Utility.Jsonize(@event.Payload, Name);
             }
         }
     }

--- a/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Utility.cs
+++ b/Extensions/src/Ncqrs.Eventing.Storage.WindowsAzure/Utility.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using System.IO;
+
+namespace Ncqrs.Eventing.Storage.WindowsAzure
+{
+    public static class Utility
+    {
+        public static string Jsonize(object data, Type type)
+        {
+            StringBuilder result = new StringBuilder();
+            new JsonSerializer().Serialize(new StringWriter(result), data);
+            return result.ToString();
+        }
+
+        public static string Jsonize(object data, string assemblyQualifiedTypeName)
+        {
+            Type parsedType = Type.GetType(assemblyQualifiedTypeName, true, true);
+            return Jsonize(data, parsedType);
+        }
+
+        public static object DeJsonize(string data, Type type)
+        {
+            return new JsonSerializer().Deserialize(new StringReader(data), type);
+        }
+
+        public static object DeJsonize(string data, string assemblyQualifiedTypeName)
+        {
+            Type parsedType = Type.GetType(assemblyQualifiedTypeName, true, true);
+            return DeJsonize(data, parsedType);
+        }
+
+    }
+}


### PR DESCRIPTION
Re-applied changes made in feature-event-store
- Split table in Azure Development Storage as emulator cannot support jagged tables
- Fixed minVersion/maxVersion failing queries when .MinValue and .MaxValue were used
- Use Json strings instead of byte[]
- Built in .OrderBy to ensure InitialVersion is always correct
