### PR TITLE
More convenient uow GetById using generics

### DIFF
--- a/Framework/src/Ncqrs/Domain/IUnitOfWorkContext.cs
+++ b/Framework/src/Ncqrs/Domain/IUnitOfWorkContext.cs
@@ -22,6 +22,29 @@ namespace Ncqrs.Domain
         AggregateRoot GetById(Type aggregateRootType, Guid eventSourceId, long? lastKnownRevision);
 
         /// <summary>
+        /// Gets aggregate root by its id.
+        /// </summary>
+        /// <param name="eventSourceId">The eventSourceId of the aggregate root.</param>
+        /// <param name="lastKnownRevision">If specified, the most recent version of event source observed by the client (used for optimistic concurrency).</param>
+        /// <returns>
+        /// A new instance of the aggregate root that contains the latest known state.
+        /// </returns>
+        TAggregateRoot GetById<TAggregateRoot>(Guid eventSourceId, long? lastKnownRevision)
+            where TAggregateRoot : AggregateRoot;
+
+        /// <summary>
+        /// Gets aggregate root by its id.
+        /// </summary>
+        /// <param name="eventSourceId">The eventSourceId of the aggregate root.</param>
+        /// <returns>
+        /// A new instance of the aggregate root that contains the latest known state.
+        /// </returns>
+        TAggregateRoot GetById<TAggregateRoot>(Guid eventSourceId)
+            where TAggregateRoot : AggregateRoot;
+
+
+        
+        /// <summary>
         /// Accept all the changes that has been made within this context. All <see cref="IEvent">events</see>
         /// that has been occured will be stored and published.
         /// </summary>

--- a/Framework/src/Ncqrs/Domain/UnitOfWorkBase.cs
+++ b/Framework/src/Ncqrs/Domain/UnitOfWorkBase.cs
@@ -111,6 +111,16 @@ namespace Ncqrs.Domain
         
 
         public abstract AggregateRoot GetById(Type aggregateRootType, Guid eventSourceId, long? lastKnownRevision);
+        public TAggregateRoot GetById<TAggregateRoot>(Guid eventSourceId, long? lastKnownRevision) where TAggregateRoot : AggregateRoot
+        {
+            return (TAggregateRoot) GetById(typeof (TAggregateRoot), eventSourceId, lastKnownRevision);
+        }
+
+        public TAggregateRoot GetById<TAggregateRoot>(Guid eventSourceId) where TAggregateRoot : AggregateRoot
+        {
+            return GetById<TAggregateRoot>(eventSourceId, null);
+        }
+
         public abstract void Accept();
     }
 }


### PR DESCRIPTION
```
var course = uow.GetById<Course>(courseId);
```

instead of 

```
var course = (Course) uow.GetById(typeof(Course), courseId, null);
```
