### PR TITLE
Fixed bug in the UpdateEventSourceVersionQuery by removing the  AND [Vers

### DIFF
--- a/Framework/src/Ncqrs/Eventing/Storage/SQL/MsSqlServerEventStore.cs
+++ b/Framework/src/Ncqrs/Eventing/Storage/SQL/MsSqlServerEventStore.cs
@@ -413,15 +413,17 @@ namespace Ncqrs.Eventing.Storage.SQL
         /// Updates the version of the <see cref="EventSource"/> in the store with the new version.
         /// </summary>
         /// <param name="eventSourceId">The <see cref="EventSource.EventSourceId"/> that is being updated.</param>
+        /// <param name="initialVersion">Indicates the initial version to use.</param>
         /// <param name="newVersion">Indicates the new version to use.</param>
         /// <param name="transaction">The transaction to enlist in while performing the action.</param>
-        private static void UpdateEventSourceVersion(Guid eventSourceId, long newVersion, SqlTransaction transaction)
+        private static void UpdateEventSourceVersion(Guid eventSourceId, long initialVersion, long newVersion, SqlTransaction transaction)
         {
             using (var command = new SqlCommand(Queries.UpdateEventSourceVersionQuery, transaction.Connection))
             {
                 command.Transaction = transaction;
                 command.Parameters.AddWithValue("Id", eventSourceId);
                 command.Parameters.AddWithValue("NewVersion", newVersion);
+                command.Parameters.AddWithValue("initialVersion", initialVersion);
                 command.ExecuteNonQuery();
             }
         }
@@ -527,7 +529,7 @@ namespace Ncqrs.Eventing.Storage.SQL
             SaveEvents(events, transaction);
 
             // Update the version of the provider.
-            UpdateEventSourceVersion(eventSourceId, eventSourceVersion, transaction);
+            UpdateEventSourceVersion(eventSourceId, initialVersion, eventSourceVersion, transaction);
         }
 
         /// <summary>

--- a/Framework/src/Ncqrs/Eventing/Storage/SQL/Queries.cs
+++ b/Framework/src/Ncqrs/Eventing/Storage/SQL/Queries.cs
@@ -20,7 +20,7 @@ namespace Ncqrs.Eventing.Storage.SQL
 
         public const String SelectVersionQuery = "SELECT [Version] FROM [EventSources] WHERE [Id] = @id";
 
-        public const String UpdateEventSourceVersionQuery = "UPDATE [EventSources] SET [Version] = @NewVersion WHERE [Id] = @id";
+        public const String UpdateEventSourceVersionQuery = "UPDATE [EventSources] SET [Version] = @NewVersion WHERE [Id] = @id AND [Version] = @initialVersion";
 
         public const String InsertSnapshot = "DELETE FROM [Snapshots] WHERE [EventSourceId]=@EventSourceId; INSERT INTO [Snapshots]([EventSourceId], [Timestamp], [Version], [Type], [Data]) VALUES (@EventSourceId, GETDATE(), @Version, @Type, @Data)";
 


### PR DESCRIPTION
Fixed bug in the UpdateEventSourceVersionQuery by removing the  AND [Version] = @initialVersion" part of the query.
