### PR TITLE
EventServiceMappedByConvention

### DIFF
--- a/Framework/src/Ncqrs/Eventing/EventServiceMappedByConvention.cs
+++ b/Framework/src/Ncqrs/Eventing/EventServiceMappedByConvention.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Ncqrs.Domain;
+using Ncqrs.Eventing.Sourcing;
+
+namespace Ncqrs.Eventing
+{
+	public abstract class EventServiceMappedByConvention : AggregateRootMappedByConvention
+	{
+		public void Raise(ISourcedEvent e)
+		{
+			var factory = NcqrsEnvironment.Get<IUnitOfWorkFactory>();
+			var context = factory.CreateUnitOfWork(e.EventIdentifier);
+
+			ApplyEvent(e);
+
+			context.Accept();
+		}
+	}
+}

--- a/Framework/src/Ncqrs/Ncqrs.csproj
+++ b/Framework/src/Ncqrs/Ncqrs.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Domain\Storage\SimpleAggregateRootCreationStrategy.cs" />
     <Compile Include="Domain\UnitOfWorkBase.cs" />
     <Compile Include="Domain\UnitOfWorkContext.cs" />
+    <Compile Include="Eventing\EventServiceMappedByConvention.cs" />
     <Compile Include="Eventing\CommittedEvent.cs" />
     <Compile Include="Eventing\CommittedEventStream.cs" />
     <Compile Include="Eventing\EventSourceInformation.cs" />


### PR DESCRIPTION
This service has been added to allow publishing events without the need of an Aggregate Root. For instance if a pure CRUD bounded context has no need of a domain model but wants to notify the remaining application of changes as they occur.

Use this service by subclassing, e.g.:

public class MyCrudContextEventSource : EventPublisherMappedByConvention
{
    protected void OnMyItemCreated(MyItemCreated evnt) { }
    protected void OnMyItemUpdated(MyItemUpdated evnt) { }
    protected void OnMyItemDeleted(MyItemDeleted evnt) { }
    // etc.
}

An event can then be published like this:

var evnt = new MyItemUpdated {
    ....
};
new MyCrudContextEventSource().Raise(evnt);

Questions? Contact me at:

Twitter: @dtraub
Mail: dennis.traub@gmail.com

By the way, I appreciate your great work! This framework has been a lot of help.

Cheers,

Dennis
