### PR TITLE
Find the exact snapshot type to avoid exceptions during FindSnapshotType

### DIFF
--- a/Extensions/src/Ncqrs.Eventing.Sourcing.Snapshotting.DynamicSnapshot/DynamicSnapshotAssembly.cs
+++ b/Extensions/src/Ncqrs.Eventing.Sourcing.Snapshotting.DynamicSnapshot/DynamicSnapshotAssembly.cs
@@ -62,7 +62,7 @@ namespace Ncqrs.Eventing.Sourcing.Snapshotting.DynamicSnapshot
         {
             LoadSnapshotAssembly();
 
-            var aggregateTypeName = aggregateType.Name;
+            var aggregateTypeName = aggregateType.Name + "_Snapshot"; 
             var snapshotType = _snapshotAssembly.GetTypes().SingleOrDefault(type => type.Name.StartsWith(aggregateTypeName));
 
             if (snapshotType == null)


### PR DESCRIPTION
FindSnapshotType  will raise exception when the name of one snapshot type is the start substring of the name of another snapshot type. For example two aggregate types: User and UserRole, 
