### PR TITLE
Properties of CommandBase are not serialized during WCF call

### DIFF
--- a/Framework/src/Ncqrs/Commanding/CommandBase.cs
+++ b/Framework/src/Ncqrs/Commanding/CommandBase.cs
@@ -21,6 +21,7 @@ namespace Ncqrs.Commanding
         /// Gets the unique identifier for this command.
         /// </summary>
         [ExcludeInMapping]
+        [DataMember]
         public Guid CommandIdentifier
         {
             get;
@@ -35,6 +36,7 @@ namespace Ncqrs.Commanding
         /// is the same as the known version.
         /// </summary>
         [ExcludeInMapping]
+        [DataMember]
         public long? KnownVersion
         { 
             get; 


### PR DESCRIPTION
CommandIdentifier and KnownVersion are not serialized when calling
CommandWebService service. Fix the issue by using DataMember attribute
