### PR TITLE
Update AggregateRootMappedByConventionTests.cs

### DIFF
--- a/Framework/src/Ncqrs.Tests/Domain/AggregateRootMappedByConventionTests.cs
+++ b/Framework/src/Ncqrs.Tests/Domain/AggregateRootMappedByConventionTests.cs
@@ -40,12 +40,12 @@ namespace Ncqrs.Tests.Domain
                 OnEventForPublicMethodInvokedCount++;
             }
 
-            public virtual void OnEventForProtectedMethod(EventForProtectedMethod e)
+            protected virtual void OnEventForProtectedMethod(EventForProtectedMethod e)
             {
                 OnEventForProtectedMethodInvokeCount++;
             }
 
-            public virtual void OnEventForPrivateMethod(EventForPrivateMethod e)
+            private virtual void OnEventForPrivateMethod(EventForPrivateMethod e)
             {
                 OnEventForPrivateMethodInvokeCount++;
             }


### PR DESCRIPTION
Maybe I'm wrong, but the names of the event handlers suggested that their visibility was set wrong.
