### PR TITLE
Update AggregateRootMappedByExpressionTests.cs

### DIFF
--- a/Framework/src/Ncqrs.Tests/Domain/AggregateRootMappedByExpressionTests.cs
+++ b/Framework/src/Ncqrs.Tests/Domain/AggregateRootMappedByExpressionTests.cs
@@ -47,12 +47,12 @@ namespace Ncqrs.Tests.Domain
                 OnEventForPublicMethodInvokedCount++;
             }
 
-            public virtual void OnEventForProtectedMethod(EventForProtectedMethod e)
+            protected virtual void OnEventForProtectedMethod(EventForProtectedMethod e)
             {
                 OnEventForProtectedMethodInvokeCount++;
             }
 
-            public virtual void OnEventForPrivateMethod(EventForPrivateMethod e)
+            private virtual void OnEventForPrivateMethod(EventForPrivateMethod e)
             {
                 OnEventForPrivateMethodInvokeCount++;
             }


### PR DESCRIPTION
Again, naming of event handlers suggested incorrect visibility.
